### PR TITLE
feat: custom category filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ ARCGIS_SERVER_API_KEY = '}zIMqHDs"4CJs$l[G.+XHSJ)Wq[?mVgr'
 ARCGIS_CLIENT_API_KEY = '}zIMqHDs"4CJs$l[G.+XHSJ)Wq[?mVgr'
 ```
 
+There is also possibility to customize [ARCGIS category filtering](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-category-filtering.htm) via list variable `ARCGIS_ADDRESS_CATEGORIES`. For example to filter out only adresses, cities and countries, you can set following:
+
+```
+ARCGIS_ADDRESS_CATEGORIES = ['Address', 'City', 'Country']
+```
+
 # The Model
 
 The rationale behind the model structure is centered on trying to make

--- a/address/static/address/js/address.js
+++ b/address/static/address/js/address.js
@@ -6,6 +6,7 @@ django.jQuery(function () {
     	select.append(option);
 	});
 	const apiKey = django.jQuery('select.address').data('select2-api-key');
+	const categories = django.jQuery('select.address').data('select2-filter-categories')
 	django.jQuery('select.address').select2({
 		minimumInputLength: 5,
 		allowClear: true,
@@ -17,7 +18,7 @@ django.jQuery(function () {
 			data: function (params) {
 				var query = {
 					text: params.term,
-					category: 'Address',
+					category: categories,
 					token: apiKey,
 					f: 'json',
 				};

--- a/address/utils.py
+++ b/address/utils.py
@@ -27,6 +27,10 @@ def geocode(raw):
         "f": "json",
         "token": settings.ARCGIS_SERVER_API_KEY,
     }
+
+    if settings.ARCGIS_ADDRESS_CATEGORIES:
+        arcgis_params["category"] = ",".join(settings.ARCGIS_ADDRESS_CATEGORIES)
+
     r = requests.get(
         "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates",
         params=arcgis_params,

--- a/address/widgets.py
+++ b/address/widgets.py
@@ -59,6 +59,11 @@ class AddressWidget(forms.Select):
         # Generate the elements. We should create a visible field for the raw.
         attrs["data-select2-default-value"] = ad.get("raw", "")
         attrs["data-select2-api-key"] = settings.ARCGIS_CLIENT_API_KEY
+        attrs["data-select2-filter-categories"] = (
+            ",".join(settings.ARCGIS_ADDRESS_CATEGORIES)
+            if hasattr(settings, "ARCGIS_ADDRESS_CATEGORIES")
+            else "Address"
+        )
         elems = [
             super(AddressWidget, self).render(
                 name, escape(ad.get("raw", "")), attrs, **kwargs


### PR DESCRIPTION
Enables custom ARCGIS category filtering via settings.ARCGIS_ADDRESS_CATEGORIES constant.

Closes: #11